### PR TITLE
Add: heart button 추가 - 레이아웃 - close #5, #1

### DIFF
--- a/src/components/Main/components/Card.tsx
+++ b/src/components/Main/components/Card.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { styled } from 'styled-components';
 import { formatPrice } from '../../../utils/formatPrice';
+import HeartSvg from './HeartSvg';
+import { useRecoilState } from 'recoil';
+import loginModal from '../../../store/loginModal';
 
 interface CardData {
   id: number;
@@ -16,11 +19,21 @@ interface CardProps {
 }
 
 const Card: React.FC<CardProps> = ({ data }) => {
+  const [openLoginModal, setOpenLoginModal] = useRecoilState(loginModal);
+  const handleHeartBtn = (e: React.MouseEvent<HTMLButtonElement>) => {
+    // ✅ Link 태그의 페이지 이동 기본 동작이 이벤트 버블링 되어 버튼 태그의 기본 동작이 됐는데, 이걸 방지해줌.
+    e.preventDefault();
+    setOpenLoginModal(!openLoginModal);
+  };
+
   return (
     <CardContainer>
-      {/* <ImgBox> */}
-      <ImgContainer url={data.images[0]} />
-      {/* </ImgBox> */}
+      <ImgBox>
+        <ImgContainer url={data.images[0]} />
+        <HeartBtn onClick={handleHeartBtn}>
+          <HeartSvg />
+        </HeartBtn>
+      </ImgBox>
       <TextWrapper>
         <DescContainer>
           <Address>{data.address}</Address>
@@ -59,7 +72,20 @@ const ImgContainer = styled.div<{ url: string }>`
   border-radius: 12px;
 `;
 
-const ImgBox = styled.div``;
+const ImgBox = styled.div`
+  position: relative;
+`;
+
+const HeartBtn = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+
+  &:active {
+    transform: scale(0.93);
+    transition: tranform 0.6s ease-in-out;
+  }
+`;
 
 const TextWrapper = styled.div``;
 

--- a/src/components/Main/components/HeartSvg.tsx
+++ b/src/components/Main/components/HeartSvg.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { styled } from 'styled-components';
+
+const HeartSvg = () => {
+  return (
+    <Svg
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox='0 0 32 32'
+      aria-hidden='true'
+      role='presentation'
+      focusable='false'
+    >
+      <path d='M16 28c7-4.73 14-10 14-17a6.98 6.98 0 0 0-7-7c-1.8 0-3.58.68-4.95 2.05L16 8.1l-2.05-2.05a6.98 6.98 0 0 0-9.9 0A6.98 6.98 0 0 0 2 11c0 7 7 12.27 14 17z'></path>
+    </Svg>
+  );
+};
+
+const Svg = styled.svg`
+  display: block;
+  height: 24px;
+  width: 24px;
+  fill: rgba(0, 0, 0, 0.5);
+  stroke: #fff;
+  stroke-width: 2;
+  /* overflow: visible; */
+`;
+
+export default HeartSvg;


### PR DESCRIPTION
### 위시리스트 클릭과 카드 클릭 시 페이지 이동 기능과 겹칠 때 어떻게 해결할 것인가?

<aside>
📌 . **`e.preventDefault();`**는 이벤트의 기본 동작을 중단시키는 메소드로, 버튼 태그는 자체적으로 가진 기본 동작은 없다. 하지만 하트버튼은 LINK태그로 감싸져 있기 때문에 이벤트 버블링에 의해 페이지 이동 동작이 전파되어 내려온다. 따라서 하트 버튼에 . **`e.preventDefault();` 를 추가하면, 전파된 Link 태그의 기본 동작인 ‘상세 숙소 페이지’ 이동이 방지되어, 로그인 모달창 기능만 띄울 수 있게 된다.**

</aside>